### PR TITLE
Properly require jade as a dependency inside compiled templates

### DIFF
--- a/jade.js
+++ b/jade.js
@@ -3563,7 +3563,7 @@ define({
     write: function (pluginName, name, write) {
         if (name in buildMap) {
             var text = buildMap[name];
-            write("define('"+pluginName+"!"+name+"', function(){ return " + text + "});\n");
+            write("define('"+pluginName+"!"+name+"', ['jade'], function(jade){ return " + text + "});\n");
         }
     },
     //>>excludeEnd('excludeJade')


### PR DESCRIPTION
This makes templates work after build even if excludePragmasOnSave.excludeJade is not defined.
With the change I got 'jade' is not defined.
