### PR TITLE
Compatibility for require.js build system

### DIFF
--- a/jade.js
+++ b/jade.js
@@ -3891,6 +3891,8 @@ exports.rethrow = function rethrow(err, filename, lineno){
 
 })({});
 
+define('jade', jade);
+
 //>>excludeStart('excludeJade', pragmas.excludeJade)
 }
 //>>excludeEnd('excludeJade')


### PR DESCRIPTION
Templates built with r.js crash because the jade object returned in define isn't a reference to the jade runtime...
